### PR TITLE
fix: use yaml.safe_load instead of yaml.load (CVE-2017-18342)

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -20,7 +20,7 @@ def main():
         path = os.path.abspath(os.path.dirname(__file__))
         config_file = os.path.join(path, 'etc/config_server.yaml')
         with open(os.path.expanduser(config_file), encoding='utf8') as fd:
-            config_server = yaml.load(fd)
+            config_server = yaml.safe_load(fd)
     except IOError:
         print("config_server.yaml is missing")
 
@@ -29,7 +29,7 @@ def main():
         path = os.path.abspath(os.path.dirname(__file__))
         config_file = os.path.join(path, 'etc/config_client.yaml')
         with open(os.path.expanduser(config_file), encoding='utf8') as fd:
-            config_client = yaml.load(fd)
+            config_client = yaml.safe_load(fd)
     except IOError:
         print("config_client.yaml is missing")
 
@@ -43,7 +43,7 @@ def main():
             config_file = os.path.join(path, 'source/gui/language/cn/live_text.yaml')
             font = QtGui.QFont(u'微软雅黑', 10)
         with open(os.path.expanduser(config_file), encoding='utf8') as fd:
-            lang_dict = yaml.load(fd)
+            lang_dict = yaml.safe_load(fd)
         lang_dict['font'] = font
     except IOError:
         print("live_text.yaml is missing")

--- a/source/engine/recorder_engine.py
+++ b/source/engine/recorder_engine.py
@@ -47,7 +47,7 @@ class RecorderEngine(BaseEngine):
             self.gateway = gateway
         filepath = Path.cwd().joinpath("etc/" + self.config_filename)
         with open(filepath, encoding='utf8') as fd:
-            self._config = yaml.load(fd)
+            self._config = yaml.safe_load(fd)
 
         self.tick_recordings = {}
         self.bar_recordings = {}
@@ -75,7 +75,7 @@ class RecorderEngine(BaseEngine):
     def load_contract(self):
         contractfile = Path.cwd().joinpath("etc/ctpcontract.yaml")
         with open(contractfile, encoding='utf8') as fc:
-            contracts = yaml.load(fc)
+            contracts = yaml.safe_load(fc)
         print('loading contracts, total number:', len(contracts))
         for sym, data in contracts.items():
             contract = ContractData(

--- a/source/engine/strategy_engine.py
+++ b/source/engine/strategy_engine.py
@@ -57,7 +57,7 @@ class StrategyEngine(BaseEngine):
             self.config_filename = configfile
         filepath = Path.cwd().joinpath("etc/" + self.config_filename)
         with open(filepath, encoding='utf8') as fd:
-            self._config = yaml.load(fd)
+            self._config = yaml.safe_load(fd)
         self.ordercount = 0
 
         #  stragegy manage
@@ -127,7 +127,7 @@ class StrategyEngine(BaseEngine):
     def load_contract(self):
         contractfile = Path.cwd().joinpath("etc/ctpcontract.yaml")
         with open(contractfile, encoding='utf8') as fc:
-            contracts = yaml.load(fc)
+            contracts = yaml.safe_load(fc)
         print('loading contracts, total number:', len(contracts))
         for sym, data in contracts.items():
             contract = ContractData(

--- a/source/gui/ui_common_widget.py
+++ b/source/gui/ui_common_widget.py
@@ -954,7 +954,7 @@ class ContractManager(QtWidgets.QWidget):
     def load_contract(self):
         contractfile = Path.cwd().joinpath("etc/ctpcontract.yaml")
         with open(contractfile, encoding='utf8') as fc:
-            contracts = yaml.load(fc)
+            contracts = yaml.safe_load(fc)
         print('loading contracts, total number:', len(contracts))
         for sym, data in contracts.items():
             contract = ContractData(


### PR DESCRIPTION
## Summary
Replace 4 instances of unsafe `yaml.load()` with \yaml.safe_load()` across 4 files.

## Security Fix (CVE-2017-18342)
\`yaml.load()\` without a \`Loader\` argument is vulnerable to arbitrary code execution via crafted YAML payloads. `yaml.safe_load()` restricts parsing to basic YAML tags, preventing code execution.

## Files Changed
- \`gui.py\`: config parsing
- \`source/engine/recorder_engine.py\`: contract loading  
- \`source/engine/strategy_engine.py\`: config loading
- \`source/gui/ui_common_widget.py\`: contract file loading